### PR TITLE
Add tests and allow outputting to a directory

### DIFF
--- a/action_app/controllers/base.py
+++ b/action_app/controllers/base.py
@@ -67,9 +67,12 @@ class Base(Controller):
 
             if directory:
                 if not os.path.exists(directory): os.mkdir(directory)
-                with open(os.path.join(directory, job.node.name + '.stdout'), 'w+') as f:
+                name = job.node.name
+                with open(os.path.join(directory, name + '.status'), 'w+') as f:
+                    f.write(str(job.status))
+                with open(os.path.join(directory, name + '.stdout'), 'w+') as f:
                     f.write(job.stdout)
-                with open(os.path.join(directory, job.node.name + '.stderr'), 'w+') as f:
+                with open(os.path.join(directory, name + '.stderr'), 'w+') as f:
                     f.write(job.stderr)
 
             render(data, 'job.mustache')

--- a/action_app/controllers/base.py
+++ b/action_app/controllers/base.py
@@ -56,6 +56,9 @@ class Base(Controller):
                 'version' : VERSION_BANNER } )
         ]
 
+    def output_mode(self):
+        return 'stdout'
+
     def add_command(cmd):
         def runner(self):
             # Selects the type: nodes or groups

--- a/action_app/controllers/base.py
+++ b/action_app/controllers/base.py
@@ -31,6 +31,8 @@ from ..core.version import get_version
 
 from jsonapi_client import ResourceTuple, Inclusion
 
+from action_app.exceptions import MissingNodesError
+
 VERSION_BANNER = """
 Run a command on a node or over a group %s
 %s
@@ -71,6 +73,14 @@ class Base(Controller):
 
             # Reassign the ticket from the response
             ticket = self.app.session.read(data).resource
+
+            # Error if no jobs where returned
+            if len(ticket.jobs) == 0:
+                if self.app.pargs.group:
+                    msg = 'Could not execute any jobs as the nodes do not exist'
+                else:
+                    msg = 'Could not execute the job as the node does not exist'
+                raise MissingNodesError(msg)
 
             # Render the jobs to the screen
             for j in ticket.jobs: self.app.render(j, 'job.mustache')

--- a/action_app/controllers/base.py
+++ b/action_app/controllers/base.py
@@ -56,9 +56,6 @@ class Base(Controller):
                 'version' : VERSION_BANNER } )
         ]
 
-    def output_directory(self):
-        return None
-
     def add_command(cmd):
         def runner(self):
             # Selects the type: nodes or groups
@@ -95,6 +92,8 @@ class Base(Controller):
             arguments = [
                 (['-g', '--group'], { 'action': 'store_true',
                     'help': "Run over the group given by 'name'" }),
+                (['-o', '--output'], { 'metavar': 'DIRECTORY',
+                    'help': "Save the results within this directory"}),
                 (['name'], dict(help='The name of the node (or group)'))
             ]
         )(runner)

--- a/action_app/controllers/base.py
+++ b/action_app/controllers/base.py
@@ -32,6 +32,7 @@ from ..core.version import get_version
 from jsonapi_client import ResourceTuple, Inclusion
 
 from action_app.exceptions import MissingNodesError
+from action_app.exceptions import OutputNotDirectoryError
 
 import os
 
@@ -67,6 +68,8 @@ class Base(Controller):
 
             if directory:
                 if not os.path.exists(directory): os.mkdir(directory)
+                if not os.path.isdir(directory):
+                    raise OutputNotDirectoryError('{} is not a directory'.format(directory))
                 name = job.node.name
                 with open(os.path.join(directory, name + '.status'), 'w+') as f:
                     f.write(str(job.status))

--- a/action_app/controllers/base.py
+++ b/action_app/controllers/base.py
@@ -56,8 +56,8 @@ class Base(Controller):
                 'version' : VERSION_BANNER } )
         ]
 
-    def output_mode(self):
-        return 'stdout'
+    def output_directory(self):
+        return None
 
     def add_command(cmd):
         def runner(self):

--- a/action_app/core/version.py
+++ b/action_app/core/version.py
@@ -27,7 +27,7 @@
 
 from cement.utils.version import get_version as cement_get_version
 
-VERSION = (0, 1, 0, 'final', 0)
+VERSION = (0, 2, 0, 'alpha', 0)
 
 def get_version(version=VERSION):
     return cement_get_version(version)

--- a/action_app/core/version.py
+++ b/action_app/core/version.py
@@ -27,7 +27,7 @@
 
 from cement.utils.version import get_version as cement_get_version
 
-VERSION = (0, 2, 0, 'alpha', 0)
+VERSION = (0, 2, 0, 'rc', 0)
 
 def get_version(version=VERSION):
     return cement_get_version(version)

--- a/action_app/exceptions.py
+++ b/action_app/exceptions.py
@@ -25,31 +25,9 @@
 # https://github.com/openflighthpc/action-client
 #===============================================================================
 
-import vcr
-import pytest
-from pytest import raises
-from action_app.main import ActionAppTest
-from action_app.exceptions import MissingNodesError
-from jsonapi_client.exceptions import DocumentError
+class Error(Exception):
+    pass
 
-@pytest.mark.vcr()
-def test_forbidden(run_app):
-    with raises(DocumentError):
-        run_app()
-
-@pytest.mark.vcr('test/cassettes/commands.yaml')
-def test_adds_commands(run_app, commands_yaml):
-    app = run_app()
-    commands = app.controller._get_exposed_commands()
-    assert list(commands_yaml.keys()) == commands
-
-@pytest.mark.vcr
-def test_missing_node(run_app):
-    with raises(MissingNodesError):
-        run_app('command1', 'missing')
-
-@pytest.mark.vcr
-def test_missing_group(run_app):
-    with raises(MissingNodesError):
-        run_app('command1', '--group', 'missing1,missing2')
+class MissingNodesError(Error):
+    pass
 

--- a/action_app/exceptions.py
+++ b/action_app/exceptions.py
@@ -31,3 +31,6 @@ class Error(Exception):
 class MissingNodesError(Error):
     pass
 
+class OutputNotDirectoryError(Error):
+    pass
+

--- a/action_app/main.py
+++ b/action_app/main.py
@@ -38,6 +38,8 @@ from jsonapi_client.exceptions import DocumentError
 from requests.auth import AuthBase
 from requests.exceptions import ConnectionError
 
+from action_app.exceptions import Error
+
 Schema = {
     'commands': { 'properties': {
         'summary': { 'type': 'string' },
@@ -194,6 +196,9 @@ def main():
             print('\n%s' % e)
             app.exit_code = 0
 
+        except Error as e:
+            print(e)
+            app.exit_code = 1
 
 if __name__ == '__main__':
     main()

--- a/action_app/main.py
+++ b/action_app/main.py
@@ -122,8 +122,8 @@ class ActionApp(App):
             Base
         ]
 
-    def __init__(self):
-        App.__init__(self)
+    def __init__(self, *arg, **kwarg):
+        App.__init__(self, *arg, **kwarg)
         self.session = None
 
     def open_session(self):

--- a/action_app/templates/job.mustache
+++ b/action_app/templates/job.mustache
@@ -1,9 +1,13 @@
+{{#long_format}}
 
 NODE:   {{ node.name }}
-STATUS: {{ status }}
+STATUS: {{ job.status }}
 STDOUT:
-{{{ stdout }}}
+{{{ job.stdout }}}
 
 STDERR:
-{{{ stderr }}}
-
+{{{ job.stderr }}}
+{{/long_format}}
+{{^long_format}}
+{{ node.name }}: {{ job.status }}
+{{/long_format}}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ ipython
 pollute
 pytest
 pytest-cov
+pytest-vcr
 coverage
 twine>=1.11.0
 setuptools>=38.6.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 
 ipython
+pollute
 pytest
 pytest-cov
 coverage

--- a/tests/cassettes/commands.yaml
+++ b/tests/cassettes/commands.yaml
@@ -1,0 +1,37 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+      authorization:
+      - REDACTED
+    method: GET
+    uri: http://localhost:6304/commands
+  response:
+    body:
+      string: "{\n  \"data\": [\n    {\n      \"type\": \"commands\",\n      \"id\"\
+        : \"command1\",\n      \"attributes\": {\n        \"name\": \"command1\",\n\
+        \        \"description\": \"First test command\",\n        \"summary\": \"\
+        First test command\"\n      },\n      \"links\": {\n        \"self\": \"/commands/command1\"\
+        \n      }\n    },\n    {\n      \"type\": \"commands\",\n      \"id\": \"\
+        command2\",\n      \"attributes\": {\n        \"name\": \"command2\",\n  \
+        \      \"description\": \"Second test command\",\n        \"summary\": \"\
+        Second test command\"\n      },\n      \"links\": {\n        \"self\": \"\
+        /commands/command2\"\n      }\n    }\n  ],\n  \"jsonapi\": {\n    \"version\"\
+        : \"1.0\"\n  },\n  \"included\": [\n\n  ]\n}"
+    headers:
+      Content-Length:
+      - '621'
+      Content-Type:
+      - application/vnd.api+json
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_adds_commands.yaml
+++ b/tests/cassettes/test_adds_commands.yaml
@@ -1,0 +1,37 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+      authorization:
+      - REDACTED
+    method: GET
+    uri: http://localhost:6304/commands
+  response:
+    body:
+      string: "{\n  \"data\": [\n    {\n      \"type\": \"commands\",\n      \"id\"\
+        : \"command1\",\n      \"attributes\": {\n        \"name\": \"command1\",\n\
+        \        \"description\": \"First test command\",\n        \"summary\": \"\
+        First test command\"\n      },\n      \"links\": {\n        \"self\": \"/commands/command1\"\
+        \n      }\n    },\n    {\n      \"type\": \"commands\",\n      \"id\": \"\
+        command2\",\n      \"attributes\": {\n        \"name\": \"command2\",\n  \
+        \      \"description\": \"Second test command\",\n        \"summary\": \"\
+        Second test command\"\n      },\n      \"links\": {\n        \"self\": \"\
+        /commands/command2\"\n      }\n    }\n  ],\n  \"jsonapi\": {\n    \"version\"\
+        : \"1.0\"\n  },\n  \"included\": [\n\n  ]\n}"
+    headers:
+      Content-Length:
+      - '621'
+      Content-Type:
+      - application/vnd.api+json
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_error_handling_if_output_is_a_file.yaml
+++ b/tests/cassettes/test_error_handling_if_output_is_a_file.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+      authorization:
+      - REDACTED
+    method: GET
+    uri: http://localhost:6304/commands
+  response:
+    body:
+      string: "{\n  \"data\": [\n    {\n      \"type\": \"commands\",\n      \"id\"\
+        : \"command1\",\n      \"attributes\": {\n        \"name\": \"command1\",\n\
+        \        \"description\": \"First test command\",\n        \"summary\": \"\
+        First test command\"\n      },\n      \"links\": {\n        \"self\": \"/commands/command1\"\
+        \n      }\n    },\n    {\n      \"type\": \"commands\",\n      \"id\": \"\
+        command2\",\n      \"attributes\": {\n        \"name\": \"command2\",\n  \
+        \      \"description\": \"Second test command\",\n        \"summary\": \"\
+        Second test command\"\n      },\n      \"links\": {\n        \"self\": \"\
+        /commands/command2\"\n      }\n    }\n  ],\n  \"jsonapi\": {\n    \"version\"\
+        : \"1.0\"\n  },\n  \"included\": [\n\n  ]\n}"
+    headers:
+      Content-Length:
+      - '621'
+      Content-Type:
+      - application/vnd.api+json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"data": {"type": "tickets", "attributes": {}, "relationships": {"context":
+      {"data": {"id": "node1", "type": "nodes"}}, "command": {"data": {"id": "command1",
+      "type": "commands"}}}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '182'
+      Content-Type:
+      - application/vnd.api+json
+      User-Agent:
+      - python-requests/2.22.0
+      authorization:
+      - REDACTED
+    method: POST
+    uri: http://localhost:6304/tickets
+  response:
+    body:
+      string: "{\n  \"data\": {\n    \"type\": \"tickets\",\n    \"id\": \"00cfd7c4dc06dfbde426966580c912863237d101\"\
+        ,\n    \"attributes\": {\n      \"true\": true\n    },\n    \"links\": {\n\
+        \      \"self\": \"/tickets/00cfd7c4dc06dfbde426966580c912863237d101\"\n \
+        \   },\n    \"relationships\": {\n      \"command\": {\n        \"links\"\
+        : {\n          \"self\": \"/tickets/00cfd7c4dc06dfbde426966580c912863237d101/relationships/command\"\
+        ,\n          \"related\": \"/tickets/00cfd7c4dc06dfbde426966580c912863237d101/command\"\
+        \n        },\n        \"data\": {\n          \"type\": \"commands\",\n   \
+        \       \"id\": \"command1\"\n        }\n      },\n      \"context\": {\n\
+        \        \"links\": {\n          \"self\": \"/tickets/00cfd7c4dc06dfbde426966580c912863237d101/relationships/context\"\
+        ,\n          \"related\": \"/tickets/00cfd7c4dc06dfbde426966580c912863237d101/context\"\
+        \n        },\n        \"data\": {\n          \"type\": \"nodes\",\n      \
+        \    \"id\": \"node1\"\n        }\n      },\n      \"jobs\": {\n        \"\
+        links\": {\n          \"self\": \"/tickets/00cfd7c4dc06dfbde426966580c912863237d101/relationships/jobs\"\
+        ,\n          \"related\": \"/tickets/00cfd7c4dc06dfbde426966580c912863237d101/jobs\"\
+        \n        },\n        \"data\": [\n          {\n            \"type\": \"jobs\"\
+        ,\n            \"id\": \"8239b3d7f65e8090542896db053dfb971fb39b90\"\n    \
+        \      }\n        ]\n      }\n    }\n  },\n  \"jsonapi\": {\n    \"version\"\
+        : \"1.0\"\n  },\n  \"included\": [\n    {\n      \"type\": \"commands\",\n\
+        \      \"id\": \"command1\",\n      \"attributes\": {\n        \"name\": \"\
+        command1\",\n        \"description\": \"First test command\",\n        \"\
+        summary\": \"First test command\"\n      },\n      \"links\": {\n        \"\
+        self\": \"/commands/command1\"\n      }\n    },\n    {\n      \"type\": \"\
+        nodes\",\n      \"id\": \"node1\",\n      \"attributes\": {\n        \"name\"\
+        : \"node1\"\n      },\n      \"links\": {\n        \"self\": \"/nodes/node1\"\
+        \n      }\n    },\n    {\n      \"type\": \"jobs\",\n      \"id\": \"8239b3d7f65e8090542896db053dfb971fb39b90\"\
+        ,\n      \"attributes\": {\n        \"stdout\": \"command 1\\n\",\n      \
+        \  \"stderr\": \"\",\n        \"status\": 0\n      },\n      \"links\": {\n\
+        \        \"self\": \"/jobs/8239b3d7f65e8090542896db053dfb971fb39b90\"\n  \
+        \    },\n      \"relationships\": {\n        \"node\": {\n          \"links\"\
+        : {\n            \"self\": \"/jobs/8239b3d7f65e8090542896db053dfb971fb39b90/relationships/node\"\
+        ,\n            \"related\": \"/jobs/8239b3d7f65e8090542896db053dfb971fb39b90/node\"\
+        \n          },\n          \"data\": {\n            \"type\": \"nodes\",\n\
+        \            \"id\": \"node1\"\n          }\n        },\n        \"ticket\"\
+        : {\n          \"links\": {\n            \"self\": \"/jobs/8239b3d7f65e8090542896db053dfb971fb39b90/relationships/ticket\"\
+        ,\n            \"related\": \"/jobs/8239b3d7f65e8090542896db053dfb971fb39b90/ticket\"\
+        \n          }\n        }\n      }\n    }\n  ]\n}"
+    headers:
+      Content-Length:
+      - '2618'
+      Content-Type:
+      - application/vnd.api+json
+      Location:
+      - /tickets/00cfd7c4dc06dfbde426966580c912863237d101
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/cassettes/test_forbidden.yaml
+++ b/tests/cassettes/test_forbidden.yaml
@@ -1,0 +1,31 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+      authorization:
+      - REDACTED
+    method: GET
+    uri: http://localhost:6304/commands
+  response:
+    body:
+      string: "{\n  \"errors\": [\n    {\n      \"id\": \"c7b5e37d-64f2-4dbd-87ac-491ed8993358\"\
+        ,\n      \"title\": \"Forbidden Error\",\n      \"detail\": \"You are not\
+        \ authorized to perform this action\",\n      \"status\": \"403\"\n    }\n\
+        \  ]\n}"
+    headers:
+      Content-Length:
+      - '206'
+      Content-Type:
+      - application/vnd.api+json
+    status:
+      code: 403
+      message: Forbidden
+version: 1

--- a/tests/cassettes/test_it_outputs_to_stdout_by_default.yaml
+++ b/tests/cassettes/test_it_outputs_to_stdout_by_default.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+      authorization:
+      - REDACTED
+    method: GET
+    uri: http://localhost:6304/commands
+  response:
+    body:
+      string: "{\n  \"data\": [\n    {\n      \"type\": \"commands\",\n      \"id\"\
+        : \"command1\",\n      \"attributes\": {\n        \"name\": \"command1\",\n\
+        \        \"description\": \"First test command\",\n        \"summary\": \"\
+        First test command\"\n      },\n      \"links\": {\n        \"self\": \"/commands/command1\"\
+        \n      }\n    },\n    {\n      \"type\": \"commands\",\n      \"id\": \"\
+        command2\",\n      \"attributes\": {\n        \"name\": \"command2\",\n  \
+        \      \"description\": \"Second test command\",\n        \"summary\": \"\
+        Second test command\"\n      },\n      \"links\": {\n        \"self\": \"\
+        /commands/command2\"\n      }\n    }\n  ],\n  \"jsonapi\": {\n    \"version\"\
+        : \"1.0\"\n  },\n  \"included\": [\n\n  ]\n}"
+    headers:
+      Content-Length:
+      - '621'
+      Content-Type:
+      - application/vnd.api+json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"data": {"type": "tickets", "attributes": {}, "relationships": {"context":
+      {"data": {"id": "node1", "type": "nodes"}}, "command": {"data": {"id": "command1",
+      "type": "commands"}}}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '182'
+      Content-Type:
+      - application/vnd.api+json
+      User-Agent:
+      - python-requests/2.22.0
+      authorization:
+      - REDACTED
+    method: POST
+    uri: http://localhost:6304/tickets
+  response:
+    body:
+      string: "{\n  \"data\": {\n    \"type\": \"tickets\",\n    \"id\": \"eb57fc14c9103e5b3c5f88fa99d335bacc474c22\"\
+        ,\n    \"attributes\": {\n      \"true\": true\n    },\n    \"links\": {\n\
+        \      \"self\": \"/tickets/eb57fc14c9103e5b3c5f88fa99d335bacc474c22\"\n \
+        \   },\n    \"relationships\": {\n      \"command\": {\n        \"links\"\
+        : {\n          \"self\": \"/tickets/eb57fc14c9103e5b3c5f88fa99d335bacc474c22/relationships/command\"\
+        ,\n          \"related\": \"/tickets/eb57fc14c9103e5b3c5f88fa99d335bacc474c22/command\"\
+        \n        },\n        \"data\": {\n          \"type\": \"commands\",\n   \
+        \       \"id\": \"command1\"\n        }\n      },\n      \"context\": {\n\
+        \        \"links\": {\n          \"self\": \"/tickets/eb57fc14c9103e5b3c5f88fa99d335bacc474c22/relationships/context\"\
+        ,\n          \"related\": \"/tickets/eb57fc14c9103e5b3c5f88fa99d335bacc474c22/context\"\
+        \n        },\n        \"data\": {\n          \"type\": \"nodes\",\n      \
+        \    \"id\": \"node1\"\n        }\n      },\n      \"jobs\": {\n        \"\
+        links\": {\n          \"self\": \"/tickets/eb57fc14c9103e5b3c5f88fa99d335bacc474c22/relationships/jobs\"\
+        ,\n          \"related\": \"/tickets/eb57fc14c9103e5b3c5f88fa99d335bacc474c22/jobs\"\
+        \n        },\n        \"data\": [\n          {\n            \"type\": \"jobs\"\
+        ,\n            \"id\": \"ff28f3ccf45d794cfc143dfeab1dd279e32dfe3b\"\n    \
+        \      }\n        ]\n      }\n    }\n  },\n  \"jsonapi\": {\n    \"version\"\
+        : \"1.0\"\n  },\n  \"included\": [\n    {\n      \"type\": \"commands\",\n\
+        \      \"id\": \"command1\",\n      \"attributes\": {\n        \"name\": \"\
+        command1\",\n        \"description\": \"First test command\",\n        \"\
+        summary\": \"First test command\"\n      },\n      \"links\": {\n        \"\
+        self\": \"/commands/command1\"\n      }\n    },\n    {\n      \"type\": \"\
+        nodes\",\n      \"id\": \"node1\",\n      \"attributes\": {\n        \"name\"\
+        : \"node1\"\n      },\n      \"links\": {\n        \"self\": \"/nodes/node1\"\
+        \n      }\n    },\n    {\n      \"type\": \"jobs\",\n      \"id\": \"ff28f3ccf45d794cfc143dfeab1dd279e32dfe3b\"\
+        ,\n      \"attributes\": {\n        \"stdout\": \"command 1\\n\",\n      \
+        \  \"stderr\": \"\",\n        \"status\": 0\n      },\n      \"links\": {\n\
+        \        \"self\": \"/jobs/ff28f3ccf45d794cfc143dfeab1dd279e32dfe3b\"\n  \
+        \    },\n      \"relationships\": {\n        \"node\": {\n          \"links\"\
+        : {\n            \"self\": \"/jobs/ff28f3ccf45d794cfc143dfeab1dd279e32dfe3b/relationships/node\"\
+        ,\n            \"related\": \"/jobs/ff28f3ccf45d794cfc143dfeab1dd279e32dfe3b/node\"\
+        \n          },\n          \"data\": {\n            \"type\": \"nodes\",\n\
+        \            \"id\": \"node1\"\n          }\n        },\n        \"ticket\"\
+        : {\n          \"links\": {\n            \"self\": \"/jobs/ff28f3ccf45d794cfc143dfeab1dd279e32dfe3b/relationships/ticket\"\
+        ,\n            \"related\": \"/jobs/ff28f3ccf45d794cfc143dfeab1dd279e32dfe3b/ticket\"\
+        \n          }\n        }\n      }\n    }\n  ]\n}"
+    headers:
+      Content-Length:
+      - '2618'
+      Content-Type:
+      - application/vnd.api+json
+      Location:
+      - /tickets/eb57fc14c9103e5b3c5f88fa99d335bacc474c22
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/cassettes/test_missing_group.yaml
+++ b/tests/cassettes/test_missing_group.yaml
@@ -1,0 +1,97 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+      authorization:
+      - REDACTED
+    method: GET
+    uri: http://localhost:6304/commands
+  response:
+    body:
+      string: "{\n  \"data\": [\n    {\n      \"type\": \"commands\",\n      \"id\"\
+        : \"command1\",\n      \"attributes\": {\n        \"name\": \"command1\",\n\
+        \        \"description\": \"First test command\",\n        \"summary\": \"\
+        First test command\"\n      },\n      \"links\": {\n        \"self\": \"/commands/command1\"\
+        \n      }\n    },\n    {\n      \"type\": \"commands\",\n      \"id\": \"\
+        command2\",\n      \"attributes\": {\n        \"name\": \"command2\",\n  \
+        \      \"description\": \"Second test command\",\n        \"summary\": \"\
+        Second test command\"\n      },\n      \"links\": {\n        \"self\": \"\
+        /commands/command2\"\n      }\n    }\n  ],\n  \"jsonapi\": {\n    \"version\"\
+        : \"1.0\"\n  },\n  \"included\": [\n\n  ]\n}"
+    headers:
+      Content-Length:
+      - '621'
+      Content-Type:
+      - application/vnd.api+json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"data": {"type": "tickets", "attributes": {}, "relationships": {"context":
+      {"data": {"id": "missing1,missing2", "type": "groups"}}, "command": {"data":
+      {"id": "command1", "type": "commands"}}}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      Content-Type:
+      - application/vnd.api+json
+      User-Agent:
+      - python-requests/2.22.0
+      authorization:
+      - REDACTED
+    method: POST
+    uri: http://localhost:6304/tickets
+  response:
+    body:
+      string: "{\n  \"data\": {\n    \"type\": \"tickets\",\n    \"id\": \"7ac1873febc730d6af0b2465b98a68f30065de56\"\
+        ,\n    \"attributes\": {\n      \"true\": true\n    },\n    \"links\": {\n\
+        \      \"self\": \"/tickets/7ac1873febc730d6af0b2465b98a68f30065de56\"\n \
+        \   },\n    \"relationships\": {\n      \"command\": {\n        \"links\"\
+        : {\n          \"self\": \"/tickets/7ac1873febc730d6af0b2465b98a68f30065de56/relationships/command\"\
+        ,\n          \"related\": \"/tickets/7ac1873febc730d6af0b2465b98a68f30065de56/command\"\
+        \n        },\n        \"data\": {\n          \"type\": \"commands\",\n   \
+        \       \"id\": \"command1\"\n        }\n      },\n      \"context\": {\n\
+        \        \"links\": {\n          \"self\": \"/tickets/7ac1873febc730d6af0b2465b98a68f30065de56/relationships/context\"\
+        ,\n          \"related\": \"/tickets/7ac1873febc730d6af0b2465b98a68f30065de56/context\"\
+        \n        },\n        \"data\": {\n          \"type\": \"groups\",\n     \
+        \     \"id\": \"missing1,missing2\"\n        }\n      },\n      \"jobs\":\
+        \ {\n        \"links\": {\n          \"self\": \"/tickets/7ac1873febc730d6af0b2465b98a68f30065de56/relationships/jobs\"\
+        ,\n          \"related\": \"/tickets/7ac1873febc730d6af0b2465b98a68f30065de56/jobs\"\
+        \n        },\n        \"data\": [\n\n        ]\n      }\n    }\n  },\n  \"\
+        jsonapi\": {\n    \"version\": \"1.0\"\n  },\n  \"included\": [\n    {\n \
+        \     \"type\": \"commands\",\n      \"id\": \"command1\",\n      \"attributes\"\
+        : {\n        \"name\": \"command1\",\n        \"description\": \"First test\
+        \ command\",\n        \"summary\": \"First test command\"\n      },\n    \
+        \  \"links\": {\n        \"self\": \"/commands/command1\"\n      }\n    },\n\
+        \    {\n      \"type\": \"groups\",\n      \"id\": \"missing1,missing2\",\n\
+        \      \"attributes\": {\n        \"name\": \"missing1,missing2\"\n      },\n\
+        \      \"links\": {\n        \"self\": \"/groups/missing1,missing2\"\n   \
+        \   },\n      \"relationships\": {\n        \"nodes\": {\n          \"links\"\
+        : {\n            \"self\": \"/groups/missing1,missing2/relationships/nodes\"\
+        ,\n            \"related\": \"/groups/missing1,missing2/nodes\"\n        \
+        \  }\n        }\n      }\n    }\n  ]\n}"
+    headers:
+      Content-Length:
+      - '1909'
+      Content-Type:
+      - application/vnd.api+json
+      Location:
+      - /tickets/7ac1873febc730d6af0b2465b98a68f30065de56
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/cassettes/test_missing_node.yaml
+++ b/tests/cassettes/test_missing_node.yaml
@@ -1,0 +1,90 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+      authorization:
+      - REDACTED
+    method: GET
+    uri: http://localhost:6304/commands
+  response:
+    body:
+      string: "{\n  \"data\": [\n    {\n      \"type\": \"commands\",\n      \"id\"\
+        : \"command1\",\n      \"attributes\": {\n        \"name\": \"command1\",\n\
+        \        \"description\": \"First test command\",\n        \"summary\": \"\
+        First test command\"\n      },\n      \"links\": {\n        \"self\": \"/commands/command1\"\
+        \n      }\n    },\n    {\n      \"type\": \"commands\",\n      \"id\": \"\
+        command2\",\n      \"attributes\": {\n        \"name\": \"command2\",\n  \
+        \      \"description\": \"Second test command\",\n        \"summary\": \"\
+        Second test command\"\n      },\n      \"links\": {\n        \"self\": \"\
+        /commands/command2\"\n      }\n    }\n  ],\n  \"jsonapi\": {\n    \"version\"\
+        : \"1.0\"\n  },\n  \"included\": [\n\n  ]\n}"
+    headers:
+      Content-Length:
+      - '621'
+      Content-Type:
+      - application/vnd.api+json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"data": {"type": "tickets", "attributes": {}, "relationships": {"context":
+      {"data": {"id": "missing", "type": "nodes"}}, "command": {"data": {"id": "command1",
+      "type": "commands"}}}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '184'
+      Content-Type:
+      - application/vnd.api+json
+      User-Agent:
+      - python-requests/2.22.0
+      authorization:
+      - REDACTED
+    method: POST
+    uri: http://localhost:6304/tickets
+  response:
+    body:
+      string: "{\n  \"data\": {\n    \"type\": \"tickets\",\n    \"id\": \"28a047f1677e169a4af61d9f1a713b6403d52aa4\"\
+        ,\n    \"attributes\": {\n      \"true\": true\n    },\n    \"links\": {\n\
+        \      \"self\": \"/tickets/28a047f1677e169a4af61d9f1a713b6403d52aa4\"\n \
+        \   },\n    \"relationships\": {\n      \"command\": {\n        \"links\"\
+        : {\n          \"self\": \"/tickets/28a047f1677e169a4af61d9f1a713b6403d52aa4/relationships/command\"\
+        ,\n          \"related\": \"/tickets/28a047f1677e169a4af61d9f1a713b6403d52aa4/command\"\
+        \n        },\n        \"data\": {\n          \"type\": \"commands\",\n   \
+        \       \"id\": \"command1\"\n        }\n      },\n      \"context\": {\n\
+        \        \"links\": {\n          \"self\": \"/tickets/28a047f1677e169a4af61d9f1a713b6403d52aa4/relationships/context\"\
+        ,\n          \"related\": \"/tickets/28a047f1677e169a4af61d9f1a713b6403d52aa4/context\"\
+        \n        },\n        \"data\": null\n      },\n      \"jobs\": {\n      \
+        \  \"links\": {\n          \"self\": \"/tickets/28a047f1677e169a4af61d9f1a713b6403d52aa4/relationships/jobs\"\
+        ,\n          \"related\": \"/tickets/28a047f1677e169a4af61d9f1a713b6403d52aa4/jobs\"\
+        \n        },\n        \"data\": [\n\n        ]\n      }\n    }\n  },\n  \"\
+        jsonapi\": {\n    \"version\": \"1.0\"\n  },\n  \"included\": [\n    {\n \
+        \     \"type\": \"commands\",\n      \"id\": \"command1\",\n      \"attributes\"\
+        : {\n        \"name\": \"command1\",\n        \"description\": \"First test\
+        \ command\",\n        \"summary\": \"First test command\"\n      },\n    \
+        \  \"links\": {\n        \"self\": \"/commands/command1\"\n      }\n    }\n\
+        \  ]\n}"
+    headers:
+      Content-Length:
+      - '1410'
+      Content-Type:
+      - application/vnd.api+json
+      Location:
+      - /tickets/28a047f1677e169a4af61d9f1a713b6403d52aa4
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/cassettes/test_saving_output_to_a_directory.yaml
+++ b/tests/cassettes/test_saving_output_to_a_directory.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+      authorization:
+      - REDACTED
+    method: GET
+    uri: http://localhost:6304/commands
+  response:
+    body:
+      string: "{\n  \"data\": [\n    {\n      \"type\": \"commands\",\n      \"id\"\
+        : \"command1\",\n      \"attributes\": {\n        \"name\": \"command1\",\n\
+        \        \"description\": \"First test command\",\n        \"summary\": \"\
+        First test command\"\n      },\n      \"links\": {\n        \"self\": \"/commands/command1\"\
+        \n      }\n    },\n    {\n      \"type\": \"commands\",\n      \"id\": \"\
+        command2\",\n      \"attributes\": {\n        \"name\": \"command2\",\n  \
+        \      \"description\": \"Second test command\",\n        \"summary\": \"\
+        Second test command\"\n      },\n      \"links\": {\n        \"self\": \"\
+        /commands/command2\"\n      }\n    }\n  ],\n  \"jsonapi\": {\n    \"version\"\
+        : \"1.0\"\n  },\n  \"included\": [\n\n  ]\n}"
+    headers:
+      Content-Length:
+      - '621'
+      Content-Type:
+      - application/vnd.api+json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"data": {"type": "tickets", "attributes": {}, "relationships": {"context":
+      {"data": {"id": "node1", "type": "nodes"}}, "command": {"data": {"id": "command1",
+      "type": "commands"}}}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '182'
+      Content-Type:
+      - application/vnd.api+json
+      User-Agent:
+      - python-requests/2.22.0
+      authorization:
+      - REDACTED
+    method: POST
+    uri: http://localhost:6304/tickets
+  response:
+    body:
+      string: "{\n  \"data\": {\n    \"type\": \"tickets\",\n    \"id\": \"b0dbc59f65e10f676e321ad65d3a73b499d06fd0\"\
+        ,\n    \"attributes\": {\n      \"true\": true\n    },\n    \"links\": {\n\
+        \      \"self\": \"/tickets/b0dbc59f65e10f676e321ad65d3a73b499d06fd0\"\n \
+        \   },\n    \"relationships\": {\n      \"command\": {\n        \"links\"\
+        : {\n          \"self\": \"/tickets/b0dbc59f65e10f676e321ad65d3a73b499d06fd0/relationships/command\"\
+        ,\n          \"related\": \"/tickets/b0dbc59f65e10f676e321ad65d3a73b499d06fd0/command\"\
+        \n        },\n        \"data\": {\n          \"type\": \"commands\",\n   \
+        \       \"id\": \"command1\"\n        }\n      },\n      \"context\": {\n\
+        \        \"links\": {\n          \"self\": \"/tickets/b0dbc59f65e10f676e321ad65d3a73b499d06fd0/relationships/context\"\
+        ,\n          \"related\": \"/tickets/b0dbc59f65e10f676e321ad65d3a73b499d06fd0/context\"\
+        \n        },\n        \"data\": {\n          \"type\": \"nodes\",\n      \
+        \    \"id\": \"node1\"\n        }\n      },\n      \"jobs\": {\n        \"\
+        links\": {\n          \"self\": \"/tickets/b0dbc59f65e10f676e321ad65d3a73b499d06fd0/relationships/jobs\"\
+        ,\n          \"related\": \"/tickets/b0dbc59f65e10f676e321ad65d3a73b499d06fd0/jobs\"\
+        \n        },\n        \"data\": [\n          {\n            \"type\": \"jobs\"\
+        ,\n            \"id\": \"f9469099c619a9ffae8cd18da5bf285aeb38f53f\"\n    \
+        \      }\n        ]\n      }\n    }\n  },\n  \"jsonapi\": {\n    \"version\"\
+        : \"1.0\"\n  },\n  \"included\": [\n    {\n      \"type\": \"commands\",\n\
+        \      \"id\": \"command1\",\n      \"attributes\": {\n        \"name\": \"\
+        command1\",\n        \"description\": \"First test command\",\n        \"\
+        summary\": \"First test command\"\n      },\n      \"links\": {\n        \"\
+        self\": \"/commands/command1\"\n      }\n    },\n    {\n      \"type\": \"\
+        nodes\",\n      \"id\": \"node1\",\n      \"attributes\": {\n        \"name\"\
+        : \"node1\"\n      },\n      \"links\": {\n        \"self\": \"/nodes/node1\"\
+        \n      }\n    },\n    {\n      \"type\": \"jobs\",\n      \"id\": \"f9469099c619a9ffae8cd18da5bf285aeb38f53f\"\
+        ,\n      \"attributes\": {\n        \"stdout\": \"command 1\\n\",\n      \
+        \  \"stderr\": \"\",\n        \"status\": 0\n      },\n      \"links\": {\n\
+        \        \"self\": \"/jobs/f9469099c619a9ffae8cd18da5bf285aeb38f53f\"\n  \
+        \    },\n      \"relationships\": {\n        \"node\": {\n          \"links\"\
+        : {\n            \"self\": \"/jobs/f9469099c619a9ffae8cd18da5bf285aeb38f53f/relationships/node\"\
+        ,\n            \"related\": \"/jobs/f9469099c619a9ffae8cd18da5bf285aeb38f53f/node\"\
+        \n          },\n          \"data\": {\n            \"type\": \"nodes\",\n\
+        \            \"id\": \"node1\"\n          }\n        },\n        \"ticket\"\
+        : {\n          \"links\": {\n            \"self\": \"/jobs/f9469099c619a9ffae8cd18da5bf285aeb38f53f/relationships/ticket\"\
+        ,\n            \"related\": \"/jobs/f9469099c619a9ffae8cd18da5bf285aeb38f53f/ticket\"\
+        \n          }\n        }\n      }\n    }\n  ]\n}"
+    headers:
+      Content-Length:
+      - '2618'
+      Content-Type:
+      - application/vnd.api+json
+      Location:
+      - /tickets/b0dbc59f65e10f676e321ad65d3a73b499d06fd0
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,3 +42,9 @@ def run_app(*argv):
 
     return _run_app
 
+@pytest.fixture(scope='module')
+def vcr_config():
+    return {
+        "filter_headers": [('authorization', 'REDACTED')],
+    }
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,15 +36,6 @@ from cement import fs
 from action_app.main import ActionAppTest
 
 @pytest.fixture
-def build_controller():
-    def _build_controller(*argv):
-        app = ActionAppTest(argv=argv)
-        app.setup()
-        return app.controller
-
-    return _build_controller
-
-@pytest.fixture
 def run_app():
     def _run_app(*argv):
         with ActionAppTest(argv=argv) as a:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,8 +36,8 @@ from cement import fs
 from action_app.main import ActionAppTest
 
 @pytest.fixture
-def run_app(*argv):
-    def _run_app():
+def run_app():
+    def _run_app(*argv):
         with ActionAppTest(argv=argv) as a:
             a.run()
             return a

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@
 PyTest Fixtures.
 """
 
+import yaml
 import pytest
 from cement import fs
 
@@ -39,8 +40,14 @@ def run_app(*argv):
     def _run_app():
         with ActionAppTest(argv=argv) as a:
             a.run()
+            return a
 
     return _run_app
+
+@pytest.fixture(scope='session')
+def commands_yaml():
+    with open('tests/fixtures/commands.yaml') as file:
+        return yaml.load(file, Loader=yaml.FullLoader)
 
 @pytest.fixture(scope='module')
 def vcr_config():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of Action Client.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Action is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Action Client. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Action Client, please visit:
+# https://github.com/openflighthpc/action-client
+#===============================================================================
+
 """
 PyTest Fixtures.
 """
@@ -5,12 +32,13 @@ PyTest Fixtures.
 import pytest
 from cement import fs
 
-@pytest.fixture(scope="function")
-def tmp(request):
-    """
-    Create a `tmp` object that geneates a unique temporary directory, and file
-    for each test function that requires it.
-    """
-    t = fs.Tmp()
-    yield t
-    t.remove()
+from action_app.main import ActionAppTest
+
+@pytest.fixture
+def run_app(*argv):
+    def _run_app():
+        with ActionAppTest(argv=argv) as a:
+            a.run()
+
+    return _run_app
+

--- a/tests/fixtures/commands.yaml
+++ b/tests/fixtures/commands.yaml
@@ -1,0 +1,11 @@
+command1:
+  help:
+    summary: First test command
+  default:
+    script: echo 'command 1'
+
+command2:
+  help:
+    summary: Second test command
+  default:
+    script: echo 'command 2'

--- a/tests/fixtures/nodes.yaml
+++ b/tests/fixtures/nodes.yaml
@@ -1,0 +1,7 @@
+node1:
+  ip: 10.101.0.1
+  fqdn: node1.example.com
+
+node2:
+  ip: 10.101.0.2
+  fqdn: node2.example.com

--- a/tests/test_action_app.py
+++ b/tests/test_action_app.py
@@ -25,6 +25,7 @@
 # https://github.com/openflighthpc/action-client
 #===============================================================================
 
+import vcr
 import pytest
 from pytest import raises
 from action_app.main import ActionAppTest
@@ -35,35 +36,9 @@ def test_forbidden(run_app):
     with raises(DocumentError):
         run_app()
 
-# def test_action_app():
-#     # test action_app without any subcommands or arguments
-#     with ActionAppTest() as app:
-#         app.run()
-#         assert app.exit_code == 0
+@pytest.mark.vcr('test/cassettes/commands.yaml')
+def test_adds_commands(run_app, commands_yaml):
+    app = run_app()
+    commands = app.controller._get_exposed_commands()
+    assert list(commands_yaml.keys()) == commands
 
-
-# def test_action_app_debug():
-#     # test that debug mode is functional
-#     argv = ['--debug']
-#     with ActionAppTest(argv=argv) as app:
-#         app.run()
-#         assert app.debug is True
-
-
-# def test_command1():
-#     # test command1 without arguments
-#     argv = ['command1']
-#     with ActionAppTest(argv=argv) as app:
-#         app.run()
-#         data,output = app.last_rendered
-#         assert data['foo'] == 'bar'
-#         assert output.find('Foo => bar')
-
-
-#     # test command1 with arguments
-#     argv = ['command1', '--foo', 'not-bar']
-#     with ActionAppTest(argv=argv) as app:
-#         app.run()
-#         data,output = app.last_rendered
-#         assert data['foo'] == 'not-bar'
-#         assert output.find('Foo => not-bar')

--- a/tests/test_action_app.py
+++ b/tests/test_action_app.py
@@ -1,36 +1,67 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of Action Client.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Action is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Action Client. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Action Client, please visit:
+# https://github.com/openflighthpc/action-client
+#===============================================================================
 
 from pytest import raises
 from action_app.main import ActionAppTest
+from requests.exceptions import ConnectionError
 
-def test_action_app():
-    # test action_app without any subcommands or arguments
-    with ActionAppTest() as app:
-        app.run()
-        assert app.exit_code == 0
+def test_missing_server(run_app):
+    with raises(ConnectionError):
+        run_app()
 
-
-def test_action_app_debug():
-    # test that debug mode is functional
-    argv = ['--debug']
-    with ActionAppTest(argv=argv) as app:
-        app.run()
-        assert app.debug is True
+# def test_action_app():
+#     # test action_app without any subcommands or arguments
+#     with ActionAppTest() as app:
+#         app.run()
+#         assert app.exit_code == 0
 
 
-def test_command1():
-    # test command1 without arguments
-    argv = ['command1']
-    with ActionAppTest(argv=argv) as app:
-        app.run()
-        data,output = app.last_rendered
-        assert data['foo'] == 'bar'
-        assert output.find('Foo => bar')
+# def test_action_app_debug():
+#     # test that debug mode is functional
+#     argv = ['--debug']
+#     with ActionAppTest(argv=argv) as app:
+#         app.run()
+#         assert app.debug is True
 
 
-    # test command1 with arguments
-    argv = ['command1', '--foo', 'not-bar']
-    with ActionAppTest(argv=argv) as app:
-        app.run()
-        data,output = app.last_rendered
-        assert data['foo'] == 'not-bar'
-        assert output.find('Foo => not-bar')
+# def test_command1():
+#     # test command1 without arguments
+#     argv = ['command1']
+#     with ActionAppTest(argv=argv) as app:
+#         app.run()
+#         data,output = app.last_rendered
+#         assert data['foo'] == 'bar'
+#         assert output.find('Foo => bar')
+
+
+#     # test command1 with arguments
+#     argv = ['command1', '--foo', 'not-bar']
+#     with ActionAppTest(argv=argv) as app:
+#         app.run()
+#         data,output = app.last_rendered
+#         assert data['foo'] == 'not-bar'
+#         assert output.find('Foo => not-bar')

--- a/tests/test_action_app.py
+++ b/tests/test_action_app.py
@@ -25,12 +25,14 @@
 # https://github.com/openflighthpc/action-client
 #===============================================================================
 
+import pytest
 from pytest import raises
 from action_app.main import ActionAppTest
-from requests.exceptions import ConnectionError
+from jsonapi_client.exceptions import DocumentError
 
-def test_missing_server(run_app):
-    with raises(ConnectionError):
+@pytest.mark.vcr()
+def test_forbidden(run_app):
+    with raises(DocumentError):
         run_app()
 
 # def test_action_app():

--- a/tests/test_base_controller.py
+++ b/tests/test_base_controller.py
@@ -27,6 +27,7 @@
 
 import pytest
 from action_app.controllers.base import Base
+from action_app.exceptions import OutputNotDirectoryError
 
 @pytest.mark.vcr
 def test_it_outputs_to_stdout_by_default(run_app):
@@ -43,4 +44,11 @@ def test_saving_output_to_a_directory(run_app, tmpdir):
     assert output.find(job.stdout) == -1
     assert stdout_path.check()
     assert stdout_path.read().find(job.stdout) != -1
+
+@pytest.mark.vcr
+def test_error_handling_if_output_is_a_file(run_app, tmpdir):
+    tmpfile = tmpdir.join('file')
+    tmpfile.write('')
+    with pytest.raises(OutputNotDirectoryError):
+        app = run_app('command1', 'node1', '-o', str(tmpfile))
 

--- a/tests/test_base_controller.py
+++ b/tests/test_base_controller.py
@@ -25,42 +25,10 @@
 # https://github.com/openflighthpc/action-client
 #===============================================================================
 
-"""
-PyTest Fixtures.
-"""
-
-import yaml
 import pytest
-from cement import fs
+from action_app.controllers.base import Base
 
-from action_app.main import ActionAppTest
-
-@pytest.fixture
-def build_controller():
-    def _build_controller(*argv):
-        app = ActionAppTest(argv=argv)
-        app.setup()
-        return app.controller
-
-    return _build_controller
-
-@pytest.fixture
-def run_app():
-    def _run_app(*argv):
-        with ActionAppTest(argv=argv) as a:
-            a.run()
-            return a
-
-    return _run_app
-
-@pytest.fixture(scope='session')
-def commands_yaml():
-    with open('tests/fixtures/commands.yaml') as file:
-        return yaml.load(file, Loader=yaml.FullLoader)
-
-@pytest.fixture(scope='module')
-def vcr_config():
-    return {
-        "filter_headers": [('authorization', 'REDACTED')],
-    }
+def test_default_node_output_mode(build_controller):
+    controller = build_controller('command1', 'missing')
+    assert controller.output_mode() == 'stdout'
 

--- a/tests/test_base_controller.py
+++ b/tests/test_base_controller.py
@@ -31,6 +31,16 @@ from action_app.controllers.base import Base
 @pytest.mark.vcr
 def test_it_outputs_to_stdout_by_default(run_app):
     app = run_app('command1', 'node1')
-    job, output = app.last_rendered
-    assert output.find(job.stdout)
+    data, output = app.last_rendered
+    assert output.find(data['job'].stdout) != -1
+
+@pytest.mark.vcr
+def test_saving_output_to_a_directory(run_app, tmpdir):
+    stdout_path = tmpdir.join('node1.stdout')
+    app = run_app('command1', 'node1', '-o', str(tmpdir))
+    data, output = app.last_rendered
+    job = data['job']
+    assert output.find(job.stdout) == -1
+    assert stdout_path.check()
+    assert stdout_path.read().find(job.stdout) != -1
 

--- a/tests/test_base_controller.py
+++ b/tests/test_base_controller.py
@@ -28,7 +28,7 @@
 import pytest
 from action_app.controllers.base import Base
 
-def test_default_node_output_mode(build_controller):
+def test_default_output_directory(build_controller):
     controller = build_controller('command1', 'missing')
-    assert controller.output_mode() == 'stdout'
+    assert controller.output_directory() == None
 

--- a/tests/test_base_controller.py
+++ b/tests/test_base_controller.py
@@ -28,7 +28,9 @@
 import pytest
 from action_app.controllers.base import Base
 
-def test_default_output_directory(build_controller):
-    controller = build_controller('command1', 'missing')
-    assert controller.output_directory() == None
+@pytest.mark.vcr
+def test_it_outputs_to_stdout_by_default(run_app):
+    app = run_app('command1', 'node1')
+    job, output = app.last_rendered
+    assert output.find(job.stdout)
 


### PR DESCRIPTION
This is an extension to the original client to allow outputting the `stdout` and `stderr` to a directory. This is useful for commands with a lot of output OR when running a command over multiple nodes.

It also strengthens the error handling if no `node` data is returned in the response.

Finally some unit tests have been added for the above behaviour.